### PR TITLE
Align simulation parameters with detector study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+*.root
+analysis_plots/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.16...3.27)
+project(CosmicMuonDetectorSimulation LANGUAGES CXX)
+
+option(WITH_GEANT4_UIVIS "Build with Geant4 UI and visualization" ON)
+
+if(WITH_GEANT4_UIVIS)
+  find_package(Geant4 REQUIRED ui_all vis_all)
+else()
+  find_package(Geant4 REQUIRED)
+endif()
+
+include(${Geant4_USE_FILE})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+set(SOURCES
+  src/main.cc
+  src/DetectorConstruction.cc
+  src/PhysicsList.cc
+  src/PrimaryGeneratorAction.cc
+  src/RunAction.cc
+  src/EventAction.cc
+  src/ScintillatorSD.cc
+  src/SiPMSD.cc
+  src/AnalysisManager.cc
+)
+
+add_executable(cosmic_muon_sim ${SOURCES})
+
+target_link_libraries(cosmic_muon_sim ${Geant4_LIBRARIES})
+
+install(TARGETS cosmic_muon_sim DESTINATION bin)
+
+file(GLOB MACROS "${PROJECT_SOURCE_DIR}/macros/*.mac")
+install(FILES ${MACROS} DESTINATION bin)
+install(FILES ${PROJECT_SOURCE_DIR}/python/analyze_data.py DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Cosmic Muon Detector Simulation (Geant4 11.4.0)
+
+This repository provides a Geant4-based simulation of a two-layer scintillator cosmic muon detector with SiPM readout, ROOT output, and a Python analysis script that generates publication-ready plots.
+
+## Features
+- Cosmic muon primary generator with $E^{-2.7}$ spectrum and $\cos^2\theta$ angular distribution.
+- Semi-transparent 63x63x1 cm scintillator panels (BC-408-like) separated by 63 cm, with highlighted 6 mm SiPMs.
+- 3D visualization macro that accumulates 50 events.
+- Electronics smearing with 41% PDE, 10 PE trigger threshold, and 335.4 ps timing resolution.
+- ROOT output with 20 histograms and 4 ntuples (Events, Hits, SiPMs, Tracks).
+- Python analysis script to generate 7 summary plots.
+
+## Build (CMake + Visual Studio)
+```bash
+mkdir build
+cd build
+cmake .. -G "Visual Studio 17 2022" -A x64
+cmake --build . --config Release
+```
+
+## Run
+Interactive visualization:
+```bash
+./cosmic_muon_sim
+```
+
+Batch mode (writes `cosmic_muon.root`):
+```bash
+./cosmic_muon_sim macros/run.mac
+```
+
+## Analysis
+```bash
+python python/analyze_data.py
+```
+
+Plots are saved to `analysis_plots/`.

--- a/include/AnalysisManager.hh
+++ b/include/AnalysisManager.hh
@@ -1,0 +1,40 @@
+#ifndef ANALYSIS_MANAGER_HH
+#define ANALYSIS_MANAGER_HH
+
+#include <G4ThreeVector.hh>
+
+class G4AnalysisManager;
+
+class AnalysisManager {
+public:
+  static AnalysisManager* Instance();
+  static void Destroy();
+
+  void Book();
+  void Save();
+  void BeginOfRun();
+  void EndOfRun();
+
+  void FillEvent(double energy_gev, double cos_theta, double phi,
+                 int charge, bool detected, double time_diff_ns,
+                 double reco_x_cm, double reco_y_cm, double chi2);
+
+  void FillHit(double x_cm, double y_cm, double z_cm, double time_ns, double edep_mev);
+  void FillPositionResidual(double residual_cm);
+  void FillSiPM(int sipm_id, double photons, double time_ns);
+  void FillTrack(double theta, double phi, double chi2, double residual_cm);
+  void FillEnergyDeposit(double edep_mev);
+  void FillPhotonYield(double photons);
+  void FillSiPMMultiplicity(int multiplicity);
+
+  void FillEfficiencyEnergy(double energy_gev, bool detected);
+  void FillEfficiencyAngle(double cos_theta, bool detected);
+
+private:
+  AnalysisManager();
+  ~AnalysisManager() = default;
+
+  G4AnalysisManager* manager_ = nullptr;
+};
+
+#endif

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -1,0 +1,37 @@
+#ifndef DETECTOR_CONSTRUCTION_HH
+#define DETECTOR_CONSTRUCTION_HH
+
+#include <G4VUserDetectorConstruction.hh>
+#include <G4ThreeVector.hh>
+#include <vector>
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4Material;
+
+class DetectorConstruction : public G4VUserDetectorConstruction {
+public:
+  DetectorConstruction();
+  ~DetectorConstruction() override = default;
+
+  G4VPhysicalVolume* Construct() override;
+  void ConstructSDandField() override;
+
+  const std::vector<G4ThreeVector>& GetScintillatorCenters() const;
+  const std::vector<G4ThreeVector>& GetSiPMCenters() const;
+
+private:
+  void DefineMaterials();
+
+  G4Material* air_ = nullptr;
+  G4Material* scintillator_ = nullptr;
+  G4Material* silicon_ = nullptr;
+
+  G4LogicalVolume* scintillator_logical_ = nullptr;
+  G4LogicalVolume* sipm_logical_ = nullptr;
+
+  std::vector<G4ThreeVector> scintillator_centers_;
+  std::vector<G4ThreeVector> sipm_centers_;
+};
+
+#endif

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -1,0 +1,39 @@
+#ifndef EVENT_ACTION_HH
+#define EVENT_ACTION_HH
+
+#include <G4UserEventAction.hh>
+#include <G4ThreeVector.hh>
+#include <vector>
+
+struct ScintHitData {
+  int layer = 0;
+  G4ThreeVector position;
+  double time_ns = 0.0;
+  double edep_mev = 0.0;
+};
+
+struct SiPMHitData {
+  int sipm_id = 0;
+  double photons = 0.0;
+  double time_ns = 0.0;
+};
+
+class EventAction : public G4UserEventAction {
+public:
+  EventAction() = default;
+  ~EventAction() override = default;
+
+  void BeginOfEventAction(const G4Event* event) override;
+  void EndOfEventAction(const G4Event* event) override;
+
+  void AddScintillatorHit(int layer, const G4ThreeVector& pos, double time_ns, double edep_mev);
+  void AddSiPMHit(int sipm_id, double photons, double time_ns);
+
+private:
+  std::vector<ScintHitData> scint_hits_;
+  std::vector<SiPMHitData> sipm_hits_;
+  double total_edep_mev_ = 0.0;
+  double total_photons_ = 0.0;
+};
+
+#endif

--- a/include/EventInformation.hh
+++ b/include/EventInformation.hh
@@ -1,0 +1,26 @@
+#ifndef EVENT_INFORMATION_HH
+#define EVENT_INFORMATION_HH
+
+#include <G4VUserEventInformation.hh>
+#include <G4ThreeVector.hh>
+
+class EventInformation : public G4VUserEventInformation {
+public:
+  void SetPrimaryEnergy(double energy) { primary_energy_ = energy; }
+  void SetPrimaryDirection(const G4ThreeVector& dir) { primary_direction_ = dir; }
+  void SetPrimaryPosition(const G4ThreeVector& pos) { primary_position_ = pos; }
+  void SetCharge(int charge) { charge_ = charge; }
+
+  double GetPrimaryEnergy() const { return primary_energy_; }
+  const G4ThreeVector& GetPrimaryDirection() const { return primary_direction_; }
+  const G4ThreeVector& GetPrimaryPosition() const { return primary_position_; }
+  int GetCharge() const { return charge_; }
+
+private:
+  double primary_energy_ = 0.0;
+  G4ThreeVector primary_direction_ = {0, 0, -1};
+  G4ThreeVector primary_position_ = {};
+  int charge_ = 0;
+};
+
+#endif

--- a/include/PhysicsList.hh
+++ b/include/PhysicsList.hh
@@ -1,0 +1,14 @@
+#ifndef PHYSICS_LIST_HH
+#define PHYSICS_LIST_HH
+
+#include <G4VModularPhysicsList.hh>
+
+class PhysicsList : public G4VModularPhysicsList {
+public:
+  PhysicsList();
+  ~PhysicsList() override = default;
+
+  void SetCuts() override;
+};
+
+#endif

--- a/include/PrimaryGeneratorAction.hh
+++ b/include/PrimaryGeneratorAction.hh
@@ -1,0 +1,23 @@
+#ifndef PRIMARY_GENERATOR_ACTION_HH
+#define PRIMARY_GENERATOR_ACTION_HH
+
+#include <G4VUserPrimaryGeneratorAction.hh>
+
+class G4ParticleGun;
+class G4Event;
+
+class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
+public:
+  PrimaryGeneratorAction();
+  ~PrimaryGeneratorAction() override;
+
+  void GeneratePrimaries(G4Event* event) override;
+
+private:
+  G4ParticleGun* particle_gun_ = nullptr;
+
+  double SampleEnergyGeV() const;
+  double SampleCosTheta() const;
+};
+
+#endif

--- a/include/RunAction.hh
+++ b/include/RunAction.hh
@@ -1,0 +1,15 @@
+#ifndef RUN_ACTION_HH
+#define RUN_ACTION_HH
+
+#include <G4UserRunAction.hh>
+
+class RunAction : public G4UserRunAction {
+public:
+  RunAction() = default;
+  ~RunAction() override = default;
+
+  void BeginOfRunAction(const G4Run*) override;
+  void EndOfRunAction(const G4Run*) override;
+};
+
+#endif

--- a/include/ScintillatorSD.hh
+++ b/include/ScintillatorSD.hh
@@ -1,0 +1,14 @@
+#ifndef SCINTILLATOR_SD_HH
+#define SCINTILLATOR_SD_HH
+
+#include <G4VSensitiveDetector.hh>
+
+class ScintillatorSD : public G4VSensitiveDetector {
+public:
+  explicit ScintillatorSD(const G4String& name);
+  ~ScintillatorSD() override = default;
+
+  G4bool ProcessHits(G4Step* step, G4TouchableHistory* history) override;
+};
+
+#endif

--- a/include/SiPMSD.hh
+++ b/include/SiPMSD.hh
@@ -1,0 +1,14 @@
+#ifndef SIPM_SD_HH
+#define SIPM_SD_HH
+
+#include <G4VSensitiveDetector.hh>
+
+class SiPMSD : public G4VSensitiveDetector {
+public:
+  explicit SiPMSD(const G4String& name);
+  ~SiPMSD() override = default;
+
+  G4bool ProcessHits(G4Step* step, G4TouchableHistory* history) override;
+};
+
+#endif

--- a/macros/run.mac
+++ b/macros/run.mac
@@ -1,0 +1,2 @@
+/run/initialize
+/run/beamOn 10000

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -1,0 +1,20 @@
+/vis/open OGL 800x600-0+0
+/vis/scene/create
+/vis/scene/add/volume
+/vis/scene/add/trajectories smooth
+/vis/scene/add/hits
+/vis/scene/endOfEventAction accumulate 50
+/vis/viewer/set/autoRefresh true
+/vis/viewer/set/style surface
+/vis/modeling/trajectories/create/drawByParticleID
+/vis/modeling/trajectories/drawByParticleID-0/default/setDrawStepPts true
+/vis/modeling/trajectories/drawByParticleID-0/default/setStepPtsSize 2
+/vis/modeling/trajectories/drawByParticleID-0/default/setLineWidth 2
+/vis/modeling/trajectories/drawByParticleID-0/default/colour 0.8 0.8 0.8
+/vis/modeling/trajectories/drawByParticleID-0/particle mu-/set 1 0 0
+/vis/modeling/trajectories/drawByParticleID-0/particle mu+/set 0 0 1
+/vis/modeling/trajectories/drawByParticleID-0/particle gamma/set 0 1 0
+
+/vis/scene/add/axes 0 0 0 0.5 m
+/run/initialize
+/run/beamOn 50

--- a/python/analyze_data.py
+++ b/python/analyze_data.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+import pathlib
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+try:
+    import uproot
+except ImportError as exc:
+    raise SystemExit("This script requires uproot. Install with: pip install uproot") from exc
+
+ROOT_FILE = pathlib.Path("cosmic_muon.root")
+OUTPUT_DIR = pathlib.Path("analysis_plots")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def _gaussian_fit(data):
+    if len(data) == 0:
+        return 0.0, 1.0
+    mean = np.mean(data)
+    sigma = np.std(data)
+    return mean, sigma
+
+
+def _hist_stats(hist):
+    counts, edges = hist
+    centers = 0.5 * (edges[1:] + edges[:-1])
+    total = np.sum(counts)
+    if total <= 0:
+        return 0.0, 1.0
+    mean = np.sum(centers * counts) / total
+    variance = np.sum(counts * (centers - mean) ** 2) / total
+    return mean, np.sqrt(variance)
+
+
+def main():
+    if not ROOT_FILE.exists():
+        raise SystemExit(f"ROOT file '{ROOT_FILE}' not found. Run the simulation first.")
+
+    with uproot.open(ROOT_FILE) as file:
+        events = file["Events"].arrays(library="np")
+        hits = file["Hits"].arrays(library="np")
+        sipms = file["SiPMs"].arrays(library="np")
+        tracks = file["Tracks"].arrays(library="np")
+        h_energy = file["energy_spectrum"].to_numpy()
+        h_edep = file["energy_deposit"].to_numpy()
+        h_photon = file["photon_yield"].to_numpy()
+        h_cos = file["cos_theta"].to_numpy()
+        h_phi = file["azimuth"].to_numpy()
+        h_hit_map = file["hit_map"].to_numpy()
+        h_chi2 = file["chi2"].to_numpy()
+        h_resid = file["position_residual"].to_numpy()
+        h_sipm = file["sipm_photons"].to_numpy()
+        h_eff_energy_total = file["eff_energy_total"].to_numpy()
+        h_eff_energy_det = file["eff_energy_detected"].to_numpy()
+        h_eff_angle_total = file["eff_angle_total"].to_numpy()
+        h_eff_angle_det = file["eff_angle_detected"].to_numpy()
+
+    # Energy distributions
+    fig, ax = plt.subplots(1, 3, figsize=(15, 4))
+    ax[0].stairs(h_energy[0], h_energy[1], fill=True, alpha=0.7)
+    ax[0].set_xlabel("Energy [GeV]")
+    ax[0].set_ylabel("Counts")
+    ax[0].set_title("Primary spectrum")
+
+    ax[1].stairs(h_edep[0], h_edep[1], fill=True, alpha=0.7, color="orange")
+    ax[1].set_xlabel("Deposited energy [MeV]")
+    ax[1].set_title("Total deposited energy")
+
+    ax[2].stairs(h_photon[0], h_photon[1], fill=True, alpha=0.7, color="green")
+    ax[2].set_xlabel("Photon yield proxy")
+    ax[2].set_title("Photon yield")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "energy_distributions.png", dpi=200)
+    plt.close(fig)
+
+    # Angular distributions
+    fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+    ax[0].stairs(h_cos[0], h_cos[1], fill=True, alpha=0.7)
+    cos_centers = 0.5 * (h_cos[1][1:] + h_cos[1][:-1])
+    ax[0].plot(cos_centers, np.max(h_cos[0]) * cos_centers**2, "k--", label=r"$\cos^2\theta$")
+    ax[0].set_xlabel("cos(theta)")
+    ax[0].set_ylabel("Counts")
+    ax[0].legend()
+
+    ax[1].stairs(h_phi[0], h_phi[1], fill=True, alpha=0.7, color="purple")
+    ax[1].set_xlabel("phi [rad]")
+    ax[1].set_ylabel("Counts")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "angular_distributions.png", dpi=200)
+    plt.close(fig)
+
+    # 2D hit map
+    fig, ax = plt.subplots(figsize=(6, 6))
+    x_edges, y_edges = h_hit_map[1], h_hit_map[2]
+    ax.pcolormesh(x_edges, y_edges, h_hit_map[0].T, cmap="viridis")
+    ax.set_xlabel("x [cm]")
+    ax.set_ylabel("y [cm]")
+    ax.set_title("Hit map")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "2d_hitmap.png", dpi=200)
+    plt.close(fig)
+
+    # Reconstruction quality
+    fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+    ax[0].stairs(h_chi2[0], h_chi2[1], fill=True, alpha=0.7)
+    ax[0].set_xlabel("chi2")
+    ax[0].set_ylabel("Counts")
+
+    track_residuals = tracks["residual_cm"] if len(tracks) else np.array([])
+    mean, sigma = _gaussian_fit(track_residuals)
+    ax[1].hist(track_residuals, bins=60, color="slateblue", alpha=0.7, density=True)
+    x_vals = np.linspace(mean - 4 * sigma, mean + 4 * sigma, 200)
+    if sigma > 0:
+        gauss = 1.0 / (sigma * np.sqrt(2 * np.pi)) * np.exp(-0.5 * ((x_vals - mean) / sigma) ** 2)
+        ax[1].plot(x_vals, gauss, "k--", label=f"track σ={sigma:.2f} cm")
+    ax[1].set_xlabel("Track residual [cm]")
+    ax[1].legend()
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "reconstruction_quality.png", dpi=200)
+    plt.close(fig)
+
+    # SiPM performance
+    fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+    ax[0].stairs(h_sipm[0], h_sipm[1], fill=True, alpha=0.7, color="red")
+    ax[0].set_xlabel("Photon proxy")
+    ax[0].set_ylabel("Counts")
+
+    ax[1].hist(sipms["sipm_id"], bins=np.arange(-0.5, 8.5, 1), color="gray")
+    ax[1].set_xlabel("SiPM ID")
+    ax[1].set_ylabel("Multiplicity")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "sipm_performance.png", dpi=200)
+    plt.close(fig)
+
+    # Efficiency studies
+    fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+    eff_energy = np.divide(h_eff_energy_det[0], h_eff_energy_total[0],
+                           out=np.zeros_like(h_eff_energy_det[0]), where=h_eff_energy_total[0] > 0)
+    eff_angle = np.divide(h_eff_angle_det[0], h_eff_angle_total[0],
+                          out=np.zeros_like(h_eff_angle_det[0]), where=h_eff_angle_total[0] > 0)
+    energy_centers = 0.5 * (h_eff_energy_total[1][1:] + h_eff_energy_total[1][:-1])
+    angle_centers = 0.5 * (h_eff_angle_total[1][1:] + h_eff_angle_total[1][:-1])
+    ax[0].plot(energy_centers, eff_energy, "o-")
+    ax[0].set_xlabel("Energy [GeV]")
+    ax[0].set_ylabel("Efficiency")
+    ax[1].plot(angle_centers, eff_angle, "o-")
+    ax[1].set_xlabel("cos(theta)")
+    ax[1].set_ylabel("Efficiency")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "efficiency_studies.png", dpi=200)
+    plt.close(fig)
+
+    # Summary plot
+    fig, axes = plt.subplots(3, 3, figsize=(12, 10))
+    axes = axes.flatten()
+    axes[0].stairs(h_energy[0], h_energy[1])
+    axes[0].set_title("Energy")
+    axes[1].stairs(h_cos[0], h_cos[1])
+    axes[1].set_title("cos(theta)")
+    axes[2].stairs(h_phi[0], h_phi[1])
+    axes[2].set_title("phi")
+    axes[3].pcolormesh(x_edges, y_edges, h_hit_map[0].T, cmap="viridis")
+    axes[3].set_title("Hit map")
+    axes[4].stairs(h_chi2[0], h_chi2[1])
+    axes[4].set_title("chi2")
+    hit_mean, hit_sigma = _hist_stats(h_resid)
+    axes[5].stairs(h_resid[0], h_resid[1])
+    axes[5].set_title(f"Hit residuals σ={hit_sigma:.2f} cm")
+    axes[6].stairs(h_sipm[0], h_sipm[1])
+    axes[6].set_title("SiPM photons")
+    axes[7].plot(energy_centers, eff_energy)
+    axes[7].set_title("Efficiency vs E")
+    axes[8].plot(angle_centers, eff_angle)
+    axes[8].set_title("Efficiency vs cos(theta)")
+    fig.tight_layout()
+    fig.savefig(OUTPUT_DIR / "summary_plot.png", dpi=200)
+    plt.close(fig)
+
+    print(f"Plots saved to {OUTPUT_DIR.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/AnalysisManager.cc
+++ b/src/AnalysisManager.cc
@@ -1,0 +1,183 @@
+#include "AnalysisManager.hh"
+
+#include <G4AnalysisManager.hh>
+#include <G4PhysicalConstants.hh>
+#include <G4SystemOfUnits.hh>
+
+namespace {
+AnalysisManager* g_instance = nullptr;
+}
+
+AnalysisManager* AnalysisManager::Instance() {
+  if (!g_instance) {
+    g_instance = new AnalysisManager();
+  }
+  return g_instance;
+}
+
+void AnalysisManager::Destroy() {
+  delete g_instance;
+  g_instance = nullptr;
+}
+
+AnalysisManager::AnalysisManager() {
+  manager_ = G4AnalysisManager::Instance();
+}
+
+void AnalysisManager::Book() {
+  manager_->SetVerboseLevel(1);
+  manager_->SetFileName("cosmic_muon");
+
+  manager_->CreateH1("energy_spectrum", "Primary energy (GeV)", 200, 0.0, 100.0);
+  manager_->CreateH1("energy_deposit", "Energy deposition per event (MeV)", 200, 0.0, 200.0);
+  manager_->CreateH1("photon_yield", "Photon yield proxy", 200, 0.0, 5000.0);
+  manager_->CreateH1("cos_theta", "cos(theta)", 120, 0.0, 1.0);
+  manager_->CreateH1("azimuth", "phi (rad)", 120, -CLHEP::pi, CLHEP::pi);
+  manager_->CreateH2("hit_map", "Hit map (cm)", 100, -50, 50, 100, -50, 50);
+  manager_->CreateH1("position_residual", "Hit position residual (cm)", 200, -10, 10);
+  manager_->CreateH1("chi2", "Track chi2", 200, 0.0, 50.0);
+  manager_->CreateH1("track_residual", "Track residual (cm)", 200, 0.0, 10.0);
+  manager_->CreateH1("sipm_photons", "SiPM photon proxy", 200, 0.0, 2000.0);
+  manager_->CreateH1("sipm_multiplicity", "SiPM multiplicity", 10, -0.5, 9.5);
+  manager_->CreateH1("time_diff", "Timing difference (ns)", 200, -20.0, 20.0);
+  manager_->CreateH1("reco_x", "Reconstructed X (cm)", 200, -50, 50);
+  manager_->CreateH1("reco_y", "Reconstructed Y (cm)", 200, -50, 50);
+  manager_->CreateH1("track_theta", "Track theta (rad)", 180, 0.0, CLHEP::pi / 2);
+  manager_->CreateH1("track_phi", "Track phi (rad)", 180, -CLHEP::pi, CLHEP::pi);
+  manager_->CreateH1("eff_energy_total", "Efficiency total vs energy (GeV)", 50, 0.0, 100.0);
+  manager_->CreateH1("eff_energy_detected", "Efficiency detected vs energy (GeV)", 50, 0.0, 100.0);
+  manager_->CreateH1("eff_angle_total", "Efficiency total vs cos(theta)", 50, 0.0, 1.0);
+  manager_->CreateH1("eff_angle_detected", "Efficiency detected vs cos(theta)", 50, 0.0, 1.0);
+
+  manager_->CreateNtuple("Events", "Event-level data");
+  manager_->CreateNtupleDColumn("energy_gev");
+  manager_->CreateNtupleDColumn("cos_theta");
+  manager_->CreateNtupleDColumn("phi");
+  manager_->CreateNtupleIColumn("charge");
+  manager_->CreateNtupleIColumn("detected");
+  manager_->CreateNtupleDColumn("time_diff_ns");
+  manager_->CreateNtupleDColumn("reco_x_cm");
+  manager_->CreateNtupleDColumn("reco_y_cm");
+  manager_->CreateNtupleDColumn("chi2");
+  manager_->FinishNtuple();
+
+  manager_->CreateNtuple("Hits", "Hit positions");
+  manager_->CreateNtupleDColumn("x_cm");
+  manager_->CreateNtupleDColumn("y_cm");
+  manager_->CreateNtupleDColumn("z_cm");
+  manager_->CreateNtupleDColumn("time_ns");
+  manager_->CreateNtupleDColumn("edep_mev");
+  manager_->FinishNtuple();
+
+  manager_->CreateNtuple("SiPMs", "SiPM responses");
+  manager_->CreateNtupleIColumn("sipm_id");
+  manager_->CreateNtupleDColumn("photons");
+  manager_->CreateNtupleDColumn("time_ns");
+  manager_->FinishNtuple();
+
+  manager_->CreateNtuple("Tracks", "Track parameters");
+  manager_->CreateNtupleDColumn("theta");
+  manager_->CreateNtupleDColumn("phi");
+  manager_->CreateNtupleDColumn("chi2");
+  manager_->CreateNtupleDColumn("residual_cm");
+  manager_->FinishNtuple();
+}
+
+void AnalysisManager::BeginOfRun() {
+  manager_->OpenFile();
+}
+
+void AnalysisManager::EndOfRun() {
+  Save();
+}
+
+void AnalysisManager::Save() {
+  manager_->Write();
+  manager_->CloseFile();
+}
+
+void AnalysisManager::FillEvent(double energy_gev, double cos_theta, double phi,
+                                int charge, bool detected, double time_diff_ns,
+                                double reco_x_cm, double reco_y_cm, double chi2) {
+  manager_->FillH1(0, energy_gev);
+  manager_->FillH1(3, cos_theta);
+  manager_->FillH1(4, phi);
+  manager_->FillH1(10, time_diff_ns);
+  manager_->FillH1(11, reco_x_cm);
+  manager_->FillH1(12, reco_y_cm);
+  manager_->FillH1(6, chi2);
+
+  manager_->FillNtupleDColumn(0, 0, energy_gev);
+  manager_->FillNtupleDColumn(0, 1, cos_theta);
+  manager_->FillNtupleDColumn(0, 2, phi);
+  manager_->FillNtupleIColumn(0, 3, charge);
+  manager_->FillNtupleIColumn(0, 4, detected ? 1 : 0);
+  manager_->FillNtupleDColumn(0, 5, time_diff_ns);
+  manager_->FillNtupleDColumn(0, 6, reco_x_cm);
+  manager_->FillNtupleDColumn(0, 7, reco_y_cm);
+  manager_->FillNtupleDColumn(0, 8, chi2);
+  manager_->AddNtupleRow(0);
+}
+
+void AnalysisManager::FillHit(double x_cm, double y_cm, double z_cm, double time_ns, double edep_mev) {
+  manager_->FillH2(0, x_cm, y_cm);
+
+  manager_->FillNtupleDColumn(1, 0, x_cm);
+  manager_->FillNtupleDColumn(1, 1, y_cm);
+  manager_->FillNtupleDColumn(1, 2, z_cm);
+  manager_->FillNtupleDColumn(1, 3, time_ns);
+  manager_->FillNtupleDColumn(1, 4, edep_mev);
+  manager_->AddNtupleRow(1);
+}
+
+void AnalysisManager::FillSiPM(int sipm_id, double photons, double time_ns) {
+  manager_->FillH1(8, photons);
+
+  manager_->FillNtupleIColumn(2, 0, sipm_id);
+  manager_->FillNtupleDColumn(2, 1, photons);
+  manager_->FillNtupleDColumn(2, 2, time_ns);
+  manager_->AddNtupleRow(2);
+}
+
+void AnalysisManager::FillPositionResidual(double residual_cm) {
+  manager_->FillH1(5, residual_cm);
+}
+
+void AnalysisManager::FillTrack(double theta, double phi, double chi2, double residual_cm) {
+  manager_->FillH1(13, theta);
+  manager_->FillH1(14, phi);
+  manager_->FillH1(6, chi2);
+  manager_->FillH1(7, residual_cm);
+
+  manager_->FillNtupleDColumn(3, 0, theta);
+  manager_->FillNtupleDColumn(3, 1, phi);
+  manager_->FillNtupleDColumn(3, 2, chi2);
+  manager_->FillNtupleDColumn(3, 3, residual_cm);
+  manager_->AddNtupleRow(3);
+}
+
+void AnalysisManager::FillEnergyDeposit(double edep_mev) {
+  manager_->FillH1(1, edep_mev);
+}
+
+void AnalysisManager::FillPhotonYield(double photons) {
+  manager_->FillH1(2, photons);
+}
+
+void AnalysisManager::FillSiPMMultiplicity(int multiplicity) {
+  manager_->FillH1(9, multiplicity);
+}
+
+void AnalysisManager::FillEfficiencyEnergy(double energy_gev, bool detected) {
+  manager_->FillH1(15, energy_gev);
+  if (detected) {
+    manager_->FillH1(16, energy_gev);
+  }
+}
+
+void AnalysisManager::FillEfficiencyAngle(double cos_theta, bool detected) {
+  manager_->FillH1(17, cos_theta);
+  if (detected) {
+    manager_->FillH1(18, cos_theta);
+  }
+}

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -1,0 +1,102 @@
+#include "DetectorConstruction.hh"
+
+#include "ScintillatorSD.hh"
+#include "SiPMSD.hh"
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
+#include <G4NistManager.hh>
+#include <G4PVPlacement.hh>
+#include <G4SDManager.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4VisAttributes.hh>
+
+DetectorConstruction::DetectorConstruction() = default;
+
+void DetectorConstruction::DefineMaterials() {
+  auto nist = G4NistManager::Instance();
+  air_ = nist->FindOrBuildMaterial("G4_AIR");
+  scintillator_ = nist->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE");
+  silicon_ = nist->FindOrBuildMaterial("G4_Si");
+}
+
+G4VPhysicalVolume* DetectorConstruction::Construct() {
+  DefineMaterials();
+
+  auto world_half = 2.5 * m;
+  auto world_solid = new G4Box("World", world_half, world_half, world_half);
+  auto world_logical = new G4LogicalVolume(world_solid, air_, "WorldLogical");
+  auto world_physical = new G4PVPlacement(nullptr, {}, world_logical, "World", nullptr, false, 0, true);
+
+  auto scintillator_xy = 31.5 * cm;
+  auto scintillator_z = 0.5 * cm;
+  auto scintillator_solid = new G4Box("Scintillator", scintillator_xy, scintillator_xy, scintillator_z);
+  scintillator_logical_ = new G4LogicalVolume(scintillator_solid, scintillator_, "ScintillatorLogical");
+
+  const G4double layer_gap = 63.0 * cm;
+  scintillator_centers_.clear();
+  scintillator_centers_.push_back({0, 0, 0});
+  scintillator_centers_.push_back({0, 0, layer_gap});
+
+  for (size_t i = 0; i < scintillator_centers_.size(); ++i) {
+    new G4PVPlacement(nullptr, scintillator_centers_[i], scintillator_logical_,
+                      "Scintillator", world_logical, false, static_cast<int>(i), true);
+  }
+
+  auto sipm_half = 0.3 * cm;
+  auto sipm_solid = new G4Box("SiPM", sipm_half, sipm_half, sipm_half);
+  sipm_logical_ = new G4LogicalVolume(sipm_solid, silicon_, "SiPMLogical");
+
+  sipm_centers_.clear();
+  const G4double sipm_offset = scintillator_xy - sipm_half;
+  std::vector<G4ThreeVector> sipm_offsets = {
+      {sipm_offset, sipm_offset, 0},
+      {-sipm_offset, sipm_offset, 0},
+      {sipm_offset, -sipm_offset, 0},
+      {-sipm_offset, -sipm_offset, 0},
+      {sipm_offset, sipm_offset, layer_gap},
+      {-sipm_offset, sipm_offset, layer_gap},
+      {sipm_offset, -sipm_offset, layer_gap},
+      {-sipm_offset, -sipm_offset, layer_gap}};
+
+  for (size_t i = 0; i < sipm_offsets.size(); ++i) {
+    sipm_centers_.push_back(sipm_offsets[i]);
+    new G4PVPlacement(nullptr, sipm_offsets[i], sipm_logical_, "SiPM",
+                      world_logical, false, static_cast<int>(i), true);
+  }
+
+  auto scint_attr = new G4VisAttributes(G4Colour(0.1, 0.6, 1.0, 0.35));
+  scint_attr->SetForceSolid(true);
+  scintillator_logical_->SetVisAttributes(scint_attr);
+
+  auto sipm_attr = new G4VisAttributes(G4Colour(1.0, 0.1, 0.1));
+  sipm_attr->SetForceSolid(true);
+  sipm_logical_->SetVisAttributes(sipm_attr);
+
+  auto world_attr = new G4VisAttributes();
+  world_attr->SetVisibility(false);
+  world_logical->SetVisAttributes(world_attr);
+
+  return world_physical;
+}
+
+void DetectorConstruction::ConstructSDandField() {
+  auto sd_manager = G4SDManager::GetSDMpointer();
+
+  auto scint_sd = new ScintillatorSD("ScintillatorSD");
+  sd_manager->AddNewDetector(scint_sd);
+  SetSensitiveDetector(scintillator_logical_, scint_sd);
+
+  auto sipm_sd = new SiPMSD("SiPMSD");
+  sd_manager->AddNewDetector(sipm_sd);
+  SetSensitiveDetector(sipm_logical_, sipm_sd);
+}
+
+const std::vector<G4ThreeVector>& DetectorConstruction::GetScintillatorCenters() const {
+  return scintillator_centers_;
+}
+
+const std::vector<G4ThreeVector>& DetectorConstruction::GetSiPMCenters() const {
+  return sipm_centers_;
+}

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -1,0 +1,252 @@
+#include "EventAction.hh"
+
+#include "AnalysisManager.hh"
+#include "EventInformation.hh"
+
+#include <G4Event.hh>
+#include <G4SystemOfUnits.hh>
+#include <Randomize.hh>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace {
+constexpr double kScintillatorHalfSizeCm = 31.5;
+constexpr double kPlaneSeparationCm = 63.0;
+constexpr double kRefractiveIndex = 1.58;
+constexpr double kLightYieldPerMeV = 10000.0;
+constexpr double kPDE = 0.41;
+constexpr double kTriggerThresholdPE = 10.0;
+constexpr double kSigmaElectronicsNs = 0.3354;
+
+struct PlaneReconstruction {
+  bool valid = false;
+  G4ThreeVector poi = {};
+  double t0_ns = 0.0;
+  double chi2 = 0.0;
+  std::vector<SiPMHitData> sipm_hits;
+};
+
+std::vector<G4ThreeVector> MakePlaneSiPMPositions(double z_cm) {
+  const double offset = kScintillatorHalfSizeCm - 0.3;
+  return {
+      {offset * cm, offset * cm, z_cm * cm},
+      {-offset * cm, offset * cm, z_cm * cm},
+      {offset * cm, -offset * cm, z_cm * cm},
+      {-offset * cm, -offset * cm, z_cm * cm},
+  };
+}
+
+PlaneReconstruction ReconstructPlane(const G4ThreeVector& hit_pos, double hit_time_ns,
+                                     double plane_z_cm, double edep_mev, int sipm_id_offset) {
+  PlaneReconstruction result;
+  const auto sipm_positions = MakePlaneSiPMPositions(plane_z_cm);
+
+  const double photons = edep_mev * kLightYieldPerMeV;
+  const double expected_pe = photons * kPDE / 4.0;
+  const double v_gamma = (CLHEP::c_light / kRefractiveIndex) / (cm / ns);
+
+  std::vector<double> measured_times;
+  measured_times.reserve(4);
+
+  for (size_t i = 0; i < sipm_positions.size(); ++i) {
+    const auto distance_cm = (hit_pos - sipm_positions[i]).mag() / cm;
+    const double tof_ns = distance_cm / v_gamma;
+    const double pe = G4Poisson(expected_pe);
+    if (pe < kTriggerThresholdPE) {
+      measured_times.push_back(std::numeric_limits<double>::quiet_NaN());
+      continue;
+    }
+    const double smeared_time = hit_time_ns + tof_ns + G4RandGauss::shoot(0.0, kSigmaElectronicsNs);
+    measured_times.push_back(smeared_time);
+    result.sipm_hits.push_back({static_cast<int>(sipm_id_offset + i), pe, smeared_time});
+  }
+
+  int valid_hits = 0;
+  for (double t : measured_times) {
+    if (std::isfinite(t)) {
+      valid_hits++;
+    }
+  }
+  if (valid_hits < 3) {
+    return result;
+  }
+
+  double best_chi2 = 1e30;
+  G4ThreeVector best_poi;
+  double best_t0 = 0.0;
+
+  for (double x_cm = -kScintillatorHalfSizeCm; x_cm <= kScintillatorHalfSizeCm; x_cm += 1.0) {
+    for (double y_cm = -kScintillatorHalfSizeCm; y_cm <= kScintillatorHalfSizeCm; y_cm += 1.0) {
+      const auto poi = G4ThreeVector(x_cm * cm, y_cm * cm, plane_z_cm * cm);
+      double t0_sum = 0.0;
+      int t0_count = 0;
+      for (size_t i = 0; i < sipm_positions.size(); ++i) {
+        if (!std::isfinite(measured_times[i])) {
+          continue;
+        }
+        const auto distance_cm = (poi - sipm_positions[i]).mag() / cm;
+        const double tof_ns = distance_cm / v_gamma;
+        t0_sum += measured_times[i] - tof_ns;
+        t0_count++;
+      }
+      if (t0_count == 0) {
+        continue;
+      }
+      const double t0 = t0_sum / t0_count;
+      double chi2 = 0.0;
+      for (size_t i = 0; i < sipm_positions.size(); ++i) {
+        if (!std::isfinite(measured_times[i])) {
+          continue;
+        }
+        const auto distance_cm = (poi - sipm_positions[i]).mag() / cm;
+        const double tof_ns = distance_cm / v_gamma;
+        const double residual = measured_times[i] - (t0 + tof_ns);
+        chi2 += (residual * residual) / (kSigmaElectronicsNs * kSigmaElectronicsNs);
+      }
+      if (chi2 < best_chi2) {
+        best_chi2 = chi2;
+        best_poi = poi;
+        best_t0 = t0;
+      }
+    }
+  }
+
+  result.valid = true;
+  result.poi = best_poi;
+  result.t0_ns = best_t0;
+  result.chi2 = best_chi2;
+  return result;
+}
+}  // namespace
+
+void EventAction::BeginOfEventAction(const G4Event*) {
+  scint_hits_.clear();
+  sipm_hits_.clear();
+  total_edep_mev_ = 0.0;
+  total_photons_ = 0.0;
+}
+
+void EventAction::EndOfEventAction(const G4Event* event) {
+  auto analysis = AnalysisManager::Instance();
+
+  bool has_layer0 = false;
+  bool has_layer1 = false;
+  double earliest_layer0 = 1e9;
+  double earliest_layer1 = 1e9;
+  G4ThreeVector sum_layer0;
+  G4ThreeVector sum_layer1;
+  int count_layer0 = 0;
+  int count_layer1 = 0;
+  double edep_layer0 = 0.0;
+  double edep_layer1 = 0.0;
+
+  for (const auto& hit : scint_hits_) {
+    analysis->FillHit(hit.position.x() / cm, hit.position.y() / cm, hit.position.z() / cm,
+                      hit.time_ns, hit.edep_mev);
+
+    if (hit.layer == 0) {
+      has_layer0 = true;
+      earliest_layer0 = std::min(earliest_layer0, hit.time_ns);
+      sum_layer0 += hit.position;
+      count_layer0++;
+      edep_layer0 += hit.edep_mev;
+    } else {
+      has_layer1 = true;
+      earliest_layer1 = std::min(earliest_layer1, hit.time_ns);
+      sum_layer1 += hit.position;
+      count_layer1++;
+      edep_layer1 += hit.edep_mev;
+    }
+  }
+
+  PlaneReconstruction plane0;
+  PlaneReconstruction plane1;
+  if (has_layer0 && count_layer0 > 0) {
+    auto avg0 = sum_layer0 / count_layer0;
+    plane0 = ReconstructPlane(avg0, earliest_layer0, 0.0, edep_layer0, 0);
+  }
+  if (has_layer1 && count_layer1 > 0) {
+    auto avg1 = sum_layer1 / count_layer1;
+    plane1 = ReconstructPlane(avg1, earliest_layer1, kPlaneSeparationCm, edep_layer1, 4);
+  }
+
+  total_photons_ = (edep_layer0 + edep_layer1) * kLightYieldPerMeV;
+  analysis->FillPhotonYield(total_photons_);
+  analysis->FillSiPMMultiplicity(static_cast<int>(plane0.sipm_hits.size() + plane1.sipm_hits.size()));
+  for (const auto& hit : plane0.sipm_hits) {
+    analysis->FillSiPM(hit.sipm_id, hit.photons, hit.time_ns);
+  }
+  for (const auto& hit : plane1.sipm_hits) {
+    analysis->FillSiPM(hit.sipm_id, hit.photons, hit.time_ns);
+  }
+
+  bool detected = plane0.valid && plane1.valid;
+  double time_diff = 0.0;
+  if (detected) {
+    time_diff = plane1.t0_ns - plane0.t0_ns;
+  }
+
+  G4ThreeVector reco_point;
+  if (detected) {
+    reco_point = (plane0.poi + plane1.poi) * 0.5;
+  }
+
+  double chi2 = 0.0;
+  double residual_cm = 0.0;
+  double theta = 0.0;
+  double phi = 0.0;
+
+  const auto* info = dynamic_cast<EventInformation*>(event->GetUserInformation());
+  double energy_gev = info ? info->GetPrimaryEnergy() : 0.0;
+  int charge = info ? info->GetCharge() : 0;
+  auto true_dir = info ? info->GetPrimaryDirection() : G4ThreeVector(0, 0, -1);
+  auto true_pos = info ? info->GetPrimaryPosition() : G4ThreeVector();
+  double cos_theta = std::abs(true_dir.z());
+  double true_phi = std::atan2(true_dir.y(), true_dir.x());
+
+  if (detected) {
+    auto reco_dir = (plane1.poi - plane0.poi).unit();
+    theta = std::acos(std::abs(reco_dir.z()));
+    phi = std::atan2(reco_dir.y(), reco_dir.x());
+
+    if (std::abs(true_dir.z()) > 1e-6) {
+      double t = (0.0 - true_pos.z()) / true_dir.z();
+      auto true_mid = true_pos + t * true_dir;
+      residual_cm = (reco_point - true_mid).mag() / cm;
+    }
+
+    chi2 = plane0.chi2 + plane1.chi2;
+
+    analysis->FillTrack(theta, phi, chi2, residual_cm);
+    analysis->FillEfficiencyEnergy(energy_gev, true);
+    analysis->FillEfficiencyAngle(cos_theta, true);
+
+    if (std::abs(true_dir.z()) > 1e-6) {
+      double t0 = (0.0 - true_pos.z()) / true_dir.z();
+      auto true_plane0 = true_pos + t0 * true_dir;
+      double t1 = (kPlaneSeparationCm * cm - true_pos.z()) / true_dir.z();
+      auto true_plane1 = true_pos + t1 * true_dir;
+      analysis->FillPositionResidual((plane0.poi - true_plane0).mag() / cm);
+      analysis->FillPositionResidual((plane1.poi - true_plane1).mag() / cm);
+    }
+  } else {
+    analysis->FillEfficiencyEnergy(energy_gev, false);
+    analysis->FillEfficiencyAngle(cos_theta, false);
+  }
+
+  analysis->FillEvent(energy_gev, cos_theta, true_phi, charge, detected, time_diff,
+                      reco_point.x() / cm, reco_point.y() / cm, chi2);
+
+  analysis->FillEnergyDeposit(total_edep_mev_);
+}
+
+void EventAction::AddScintillatorHit(int layer, const G4ThreeVector& pos, double time_ns, double edep_mev) {
+  scint_hits_.push_back({layer, pos, time_ns, edep_mev});
+  total_edep_mev_ += edep_mev;
+}
+
+void EventAction::AddSiPMHit(int sipm_id, double photons, double time_ns) {
+  sipm_hits_.push_back({sipm_id, photons, time_ns});
+  total_photons_ += photons;
+}

--- a/src/PhysicsList.cc
+++ b/src/PhysicsList.cc
@@ -1,0 +1,19 @@
+#include "PhysicsList.hh"
+
+#include <G4DecayPhysics.hh>
+#include <G4EmStandardPhysics.hh>
+#include <G4HadronPhysicsFTFP_BERT.hh>
+#include <G4IonPhysics.hh>
+#include <G4SystemOfUnits.hh>
+
+PhysicsList::PhysicsList() {
+  SetVerboseLevel(1);
+  RegisterPhysics(new G4EmStandardPhysics());
+  RegisterPhysics(new G4DecayPhysics());
+  RegisterPhysics(new G4HadronPhysicsFTFP_BERT());
+  RegisterPhysics(new G4IonPhysics());
+}
+
+void PhysicsList::SetCuts() {
+  SetCutsWithDefault();
+}

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -1,0 +1,79 @@
+#include "PrimaryGeneratorAction.hh"
+
+#include "EventInformation.hh"
+
+#include <G4Event.hh>
+#include <G4ParticleGun.hh>
+#include <G4ParticleTable.hh>
+#include <G4PhysicalConstants.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4ThreeVector.hh>
+#include <Randomize.hh>
+#include <cmath>
+
+PrimaryGeneratorAction::PrimaryGeneratorAction() {
+  particle_gun_ = new G4ParticleGun(1);
+}
+
+PrimaryGeneratorAction::~PrimaryGeneratorAction() {
+  delete particle_gun_;
+}
+
+void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event) {
+  const auto energy_gev = SampleEnergyGeV();
+  const auto energy = energy_gev * GeV;
+
+  const auto cos_theta = SampleCosTheta();
+  const auto sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
+  const auto phi = 2.0 * CLHEP::pi * G4UniformRand();
+
+  const auto direction = G4ThreeVector(sin_theta * std::cos(phi),
+                                       sin_theta * std::sin(phi),
+                                       -cos_theta);
+
+  const auto plane_half = 40.0 * cm;
+  const auto x0 = (G4UniformRand() * 2.0 - 1.0) * plane_half;
+  const auto y0 = (G4UniformRand() * 2.0 - 1.0) * plane_half;
+  auto position = G4ThreeVector(x0, y0, 2.0 * m);
+
+  const double mu_plus_ratio = 1.25;
+  const bool is_mu_plus = (G4UniformRand() < (mu_plus_ratio / (1.0 + mu_plus_ratio)));
+  auto particle_name = is_mu_plus ? "mu+" : "mu-";
+  auto particle_def = G4ParticleTable::GetParticleTable()->FindParticle(particle_name);
+
+  particle_gun_->SetParticleDefinition(particle_def);
+  particle_gun_->SetParticleEnergy(energy);
+  particle_gun_->SetParticleMomentumDirection(direction);
+  particle_gun_->SetParticlePosition(position);
+
+  auto info = new EventInformation();
+  info->SetPrimaryEnergy(energy_gev);
+  info->SetPrimaryDirection(direction);
+  info->SetPrimaryPosition(position);
+  info->SetCharge(is_mu_plus ? 1 : -1);
+  event->SetUserInformation(info);
+
+  particle_gun_->GeneratePrimaryVertex(event);
+}
+
+double PrimaryGeneratorAction::SampleEnergyGeV() const {
+  const double e_min = 1.0;
+  const double e_max = 100.0;
+  const double gamma = 2.7;
+
+  const double pow_min = std::pow(e_min, 1.0 - gamma);
+  const double pow_max = std::pow(e_max, 1.0 - gamma);
+  const double rnd = G4UniformRand();
+  const double energy = std::pow(pow_min + rnd * (pow_max - pow_min), 1.0 / (1.0 - gamma));
+  return energy;
+}
+
+double PrimaryGeneratorAction::SampleCosTheta() const {
+  while (true) {
+    const double cos_theta = G4UniformRand();
+    const double accept = cos_theta * cos_theta;
+    if (G4UniformRand() < accept) {
+      return cos_theta;
+    }
+  }
+}

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -1,0 +1,17 @@
+#include "RunAction.hh"
+
+#include "AnalysisManager.hh"
+
+#include <G4Run.hh>
+
+void RunAction::BeginOfRunAction(const G4Run*) {
+  auto analysis = AnalysisManager::Instance();
+  analysis->Book();
+  analysis->BeginOfRun();
+}
+
+void RunAction::EndOfRunAction(const G4Run*) {
+  auto analysis = AnalysisManager::Instance();
+  analysis->EndOfRun();
+  AnalysisManager::Destroy();
+}

--- a/src/ScintillatorSD.cc
+++ b/src/ScintillatorSD.cc
@@ -1,0 +1,31 @@
+#include "ScintillatorSD.hh"
+
+#include "EventAction.hh"
+
+#include <G4EventManager.hh>
+#include <G4Step.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4TouchableHistory.hh>
+
+ScintillatorSD::ScintillatorSD(const G4String& name) : G4VSensitiveDetector(name) {}
+
+G4bool ScintillatorSD::ProcessHits(G4Step* step, G4TouchableHistory*) {
+  const auto edep = step->GetTotalEnergyDeposit();
+  if (edep <= 0.0) {
+    return false;
+  }
+
+  auto event_action = static_cast<EventAction*>(G4EventManager::GetEventManager()->GetUserEventAction());
+  if (!event_action) {
+    return false;
+  }
+
+  const auto touchable = step->GetPreStepPoint()->GetTouchable();
+  const auto layer = touchable->GetCopyNumber();
+  const auto pos = step->GetPreStepPoint()->GetPosition();
+  const auto time_ns = step->GetPreStepPoint()->GetGlobalTime() / ns;
+  const auto edep_mev = edep / MeV;
+
+  event_action->AddScintillatorHit(layer, pos, time_ns, edep_mev);
+  return true;
+}

--- a/src/SiPMSD.cc
+++ b/src/SiPMSD.cc
@@ -1,0 +1,9 @@
+#include "SiPMSD.hh"
+
+#include <G4Step.hh>
+
+SiPMSD::SiPMSD(const G4String& name) : G4VSensitiveDetector(name) {}
+
+G4bool SiPMSD::ProcessHits(G4Step*, G4TouchableHistory*) {
+  return false;
+}

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,0 +1,46 @@
+#include "DetectorConstruction.hh"
+#include "EventAction.hh"
+#include "PhysicsList.hh"
+#include "PrimaryGeneratorAction.hh"
+#include "RunAction.hh"
+
+#include <G4RunManagerFactory.hh>
+#include <G4UIExecutive.hh>
+#include <G4UImanager.hh>
+#include <G4VisExecutive.hh>
+
+int main(int argc, char** argv) {
+  auto run_manager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
+
+  run_manager->SetUserInitialization(new DetectorConstruction());
+  run_manager->SetUserInitialization(new PhysicsList());
+
+  run_manager->SetUserAction(new PrimaryGeneratorAction());
+  run_manager->SetUserAction(new RunAction());
+  run_manager->SetUserAction(new EventAction());
+
+  run_manager->Initialize();
+
+  G4UIExecutive* ui = nullptr;
+  if (argc == 1) {
+    ui = new G4UIExecutive(argc, argv);
+  }
+
+  auto vis_manager = new G4VisExecutive();
+  vis_manager->Initialize();
+
+  auto ui_manager = G4UImanager::GetUIpointer();
+  if (ui) {
+    ui_manager->ApplyCommand("/control/execute macros/vis.mac");
+    ui->SessionStart();
+    delete ui;
+  } else {
+    auto command = G4String("/control/execute ");
+    G4String file_name = argv[1];
+    ui_manager->ApplyCommand(command + file_name);
+  }
+
+  delete vis_manager;
+  delete run_manager;
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Bring the simulation geometry, source sampling and readout modeling into agreement with the detector study parameters (63×63×1 cm scintillators, 63 cm separation, 6 mm SiPMs and a larger source plane).  
- Replace ad-hoc SiPM hit wiring with a time-of-flight + PDE + threshold + electronics-smearing model and a χ²-based plane reconstruction to enable realistic hit/track residual studies.  
- Preserve the interactive 3D visualization and the existing analysis/plotting outputs while adding diagnostics needed by the study.  

### Description
- Updated detector geometry and visualization in `src/DetectorConstruction.cc` to use 31.5 cm half-size scintillators (63×63×1 cm), a 63 cm plane separation, 6 mm SiPMs (0.3 cm half-size) and an enlarged world volume, while keeping the semi-transparent visuals and SiPM highlighting.  
- Adjusted the primary generator in `src/PrimaryGeneratorAction.cc` to sample primaries uniformly over a larger source plane, keep the `E^{-2.7}` spectrum and cos^2-like acceptance, and set the mu+/mu- ratio to 1.25.  
- Reworked event-level readout in `src/EventAction.cc` to synthesize SiPM responses from scintillator hits using a Poisson photon draw, `PDE=0.41`, a `10 PE` trigger threshold, time-of-flight propagation, and Gaussian electronics smearing (`σ=335.4 ps`), followed by a grid-search χ² plane reconstruction that produces per-plane `poi`, `t0` and `chi2`; `SiPMSD::ProcessHits` is now a no-op because SiPM signals are synthesized from scintillator energy deposits.  
- Expanded analysis support in `include/AnalysisManager.hh` / `src/AnalysisManager.cc` with a hit position residual histogram and reindexed/added histograms/ntuples to record hits, SiPM responses and track residuals, and updated the Python plotting in `python/analyze_data.py` to report hit/track residual statistics and nicer labels.  
- Updated `README.md` to document the new detector parameters, readout model (PDE, threshold, timing smearing) and the produced ROOT/plot outputs.  

### Testing
- No automated tests were executed in this environment after the changes were applied.  
- The changes were committed to the repository (commit message: `Align simulation parameters with detector study`) but no build or runtime validation was performed here.  
- The repository includes `CMakeLists.txt` and run/visualization macros so users can build and validate locally with `cmake` and `./cosmic_muon_sim macros/run.mac`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698892cce7208322827d78d9248cf1fb)